### PR TITLE
Check for missing 'unzip' command.

### DIFF
--- a/pxe-setup.sh
+++ b/pxe-setup.sh
@@ -19,6 +19,12 @@ WHITE='\033[1;37m'
 NOCOLOR='\033[0m'
 
 
+if ! command -v unzip &> /dev/null
+then
+    echo -e "${RED}> Command 'unzip' not found.  Try 'apt install unzip'.${NOCOLOR}"
+    exit
+fi
+
 dir=$1
 [[ $dir == "/" ]] && dir=""
 echo


### PR DESCRIPTION
Ubuntu Server 20.04.2 does not contain the unzip command by default which is used by `pxe-setup.sh`.

Without this command, you get the following error, because the package is never unzipped:
![image](https://user-images.githubusercontent.com/25350725/109313932-5b34e300-780e-11eb-81c3-c320b8457689.png)

After this update, this is what an install looks like on a server without the command installed.
![image](https://user-images.githubusercontent.com/25350725/109314380-e1e9c000-780e-11eb-9393-8403fd1d1da4.png)
