### PR TITLE
Fixes for hive-upgrade and pxe-config

### DIFF
--- a/pxeserver/hive-upgrade.sh
+++ b/pxeserver/hive-upgrade.sh
@@ -87,6 +87,8 @@ mount --bind /dev  ${TMP_DIR}/root/dev
 mount --bind /run  ${TMP_DIR}/root/run
 #exit
 
+mv ./etc/resolv.conf{,.bak}
+cp /etc/resolv.conf ./etc/resolv.conf
 
 cat << EOF | chroot ${TMP_DIR}/root	
 export PATH="./:/hive/bin:/hive/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"

--- a/pxeserver/pxe-config.sh
+++ b/pxeserver/pxe-config.sh
@@ -206,7 +206,7 @@ cp $SYS_CONF"/etc/dnsmasq.conf" /etc
 echo "DNSMASQ_EXCEPT=lo" >> /etc/default/dnsmasq
 
 [[ ! -d /var/www/html ]] && mkdir -p /var/www/html
-[[ ! -e /var/www/html/hiveramfs ]] && ln -s $HTTP_ROOT /var/www/html
+[[ ! -e /var/www/html/hiveramfs ]] && ln -sf $HTTP_ROOT /var/www/html
 cp -R /etc/nginx $SYS_CONF/etc/nginx.bak
 cp -R $SYS_CONF/etc/nginx /etc
 
@@ -243,12 +243,12 @@ else
 	echo -e "${GREEN}OK${NOCOLOR}"
 fi
 #making uefi
-grub-mkimage -d /usr/lib/grub/x86_64-efi/ -O x86_64-efi -o /pxeserver/tftp/efi/grubnetx64.efi --prefix="(tftp,$IP)/efi" efinet tftp efi_uga efi_gop http
-chmod -R 777 /pxeserver/
-#make sed /pxeserver/tftp/efi/grub.cfg
-sed -i "/set net_default_server=/c set net_default_server=$IP" /pxeserver/tftp/efi/grub.cfg
-sed -i "/set fs_size=/c set fs_size=${FS_SIZE}M" /pxeserver/tftp/efi/grub.cfg
-sed -i "/set arch_name=/c set arch_name=$ARCH_NAME" /pxeserver/tftp/efi/grub.cfg
+grub-mkimage -d /usr/lib/grub/x86_64-efi/ -O x86_64-efi -o $mydir/tftp/efi/grubnetx64.efi --prefix="(tftp,$IP)/efi" efinet tftp efi_uga efi_gop http
+chmod -R 777 $mydir/
+#make sed $mydir/tftp/efi/grub.cfg
+sed -i "/set net_default_server=/c set net_default_server=$IP" $mydir/tftp/efi/grub.cfg
+sed -i "/set fs_size=/c set fs_size=${FS_SIZE}M" $mydir/tftp/efi/grub.cfg
+sed -i "/set arch_name=/c set arch_name=$ARCH_NAME" $mydir/tftp/efi/grub.cfg
 #finished making uefi
 echo
 [[ $res != 0 ]] && echo -e "${RED}Server install failed${NOCOLOR}" && exit 1


### PR DESCRIPTION
There was an issue in the pxe-config.sh script that will look for /pxeserver/ but if you changed the directory during install it will not find the correct directory to make the UEFI changes. By changing to the variable $mydir instead of the full path listed this is fixed.

There is also an error for some while chrooting with the hive-upgrade.sh it will not get any internet connection to upgrade, there is a fix for this by copying the main servers /etc/resolv.conf